### PR TITLE
Py 3.7.x version of base62 script

### DIFF
--- a/Base62/base62_py37x.py
+++ b/Base62/base62_py37x.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# http://www.zhihua-lai.com/
+# base62 convert for python 3.7.x
+
+from math import floor
+base = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+b = 62;
+def toBase10(b62: str) -> int:
+    limit = len(b62)
+    res = 0
+    for i in range(limit):
+        res = b * res + base.find(b62[i])
+    return res
+def toBase62(b10: int) -> str:
+    if b <= 0 or b > 62:
+        return 0
+    r = b10 % b
+    res = base[r];
+    q = floor(b10 / b)
+    while q:
+        r = q % b
+        q = floor(q / b)
+        res = base[int(r)] + res
+    return res


### PR DESCRIPTION
Hello Doctor Lai,

I wanted to use your algorithm for Base62 and Base10 conversions. It did not work for Python `3.7.x`, the current latest version so I made some updates to it. Hopefully there was no loss of optimizations.

I know Python `2.x` is a lot more supported for academia but figured an extra version for Python `3.6.x`+ wouldn't hurt your existing repo. Also, `range` is supposed to be faster than `xrange` so you might actually see some minor improvements.


Best Wishes,
an unsolicited contributor :wink: